### PR TITLE
fixed infinite loading

### DIFF
--- a/src/main/java/fathertoast/specialai/config/util/EntityEntry.java
+++ b/src/main/java/fathertoast/specialai/config/util/EntityEntry.java
@@ -55,7 +55,7 @@ public class EntityEntry {
                 final Entity entity = TYPE.create( world );
                 if( entity != null ) {
                     entityClass = entity.getClass();
-                    entity.kill();
+                    entity.remove();
                 }
             }
             catch( Exception ex ) {


### PR DESCRIPTION
simple change. Entity#remove() bypasses all death checks, unlike entity#kill().